### PR TITLE
Bump tile version

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -14,8 +14,8 @@ The Pivotal Cloud Foundry&reg; (PCF) Metrics tile stores metrics data from appli
 
 <dl>
 <dt>Current PCF Metrics Details</dt>
-<dd><strong>Version</strong>: 1.0.3</dd>
-<dd><strong>Release Date</strong>: 4/18/2016</dd>
+<dd><strong>Version</strong>: 1.0.8</dd>
+<dd><strong>Release Date</strong>: 6/23/20166</dd>
 <dd><strong>Compatible Ops Manager Version(s)</strong>: >= 1.6.0</dd>
 <dd><strong>Compatible Elastic Runtime Version(s)</strong>: >= 1.6.16</dd>
 <dd><strong>AWS support?</strong> Yes<dd>


### PR DESCRIPTION
We just released v1.0.8 with a key fix.