### PR TITLE
Update rn-ki.html.md.erb

### DIFF
--- a/rn-ki.html.md.erb
+++ b/rn-ki.html.md.erb
@@ -20,6 +20,7 @@ Consider the following updates when configuring and deploying PCF Metrics 1.2.1:
 * **MySQL Alerts**: You can now specify an email address that receives alerts from PCF Metrics about MySQL storage issues. See the [MySQL Alerts](./installing.html#alerts) section of the _Installing PCF Metrics_ topic. 
 * **Data Store**: You can now configure additional properties in the **Data Store** pane. See the [Data Store](./installing.html#data) section of the _Installing PCF Metrics_ topic. 
 * **Errands**: The tile includes new errands. See the [Errands](./installing.html#data) section of the _Installing PCF Metrics_ topic. 
+    * The new Smoke Test tile errand will summarize any errors that have occured during the test, linking directly to new [troubleshooting documentation](./troubleshooting.html#smoke-test).
 * **Resource Config**: See the [Increased Data Persistence](#persistence) section below to learn about updates affecting this configuration pane. 
 * **Stemcell**: This release uses stemcell version 3263.
 


### PR DESCRIPTION
I want us to be more specific in the RN pointing out we have smoke tests in 1.2 now. While we have new errands, the others are more replacement errands, where the smoke test errand itself is truly a new errand feature for the tile. We get asked when we will have these, and the fact we have them to the newer standard (readable and linking to docs) is a big deal. I want readers to know without having to leave the RN page that we have these smoke tests now. Feel free to edit the suggested content line.