### PR TITLE
Update v1.2 compatible versions to exclude v1.10

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -22,9 +22,9 @@ To help you troubleshoot, you can also see log output for that same time period.
 <dt>Current PCF Metrics Details</dt>
 <dd><strong>Version</strong>: v1.2</dd>
 <dd><strong>Release Date</strong>: November 29, 2016</dd>
-<dd><strong>Compatible Ops Manager Version(s) for Install</strong>: v1.8.0 and later</dd>
-<dd><strong>Compatible Ops Manager Version(s) for Upgrade</strong>: v1.7.8 and later</dd>
-<dd><strong>Compatible Elastic Runtime Version(s)</strong>: v1.8.9 and later</dd>
+<dd><strong>Compatible Ops Manager Version(s) for Install</strong>: v1.8.0 through v1.9.*</dd>
+<dd><strong>Compatible Ops Manager Version(s) for Upgrade</strong>: v1.7.8 through v1.9.*</dd>
+<dd><strong>Compatible Elastic Runtime Version(s)</strong>: v1.8.9 through v1.9.*</dd>
 <dd><strong>AWS support?</strong> Yes<dd>
 <dd><strong>Azure support?</strong> Yes<dd>
 <dd><strong>GCP support?</strong> Yes</dd>


### PR DESCRIPTION
PCF Metrics v1.2 is not compatible with ERT 1.10. See story 
https://www.pivotaltracker.com/story/show/142632217