### PR TITLE
Redis Resource Config update

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -187,7 +187,7 @@ To properly configure the **Errands** pane, follow the procedure that correspond
     </tr>
     <tr>
       <td>Redis</td>
-      <td>1 (Not configurable)</td>
+      <td>1</td>
       <td>10&nbsp;GB</td>
       <td>4</td>
       <td>4&nbsp;GB</td>


### PR DESCRIPTION
Removing the "(Not configurable)" flag for Redis. It is configurable in 1.4.x.