### PR TITLE
Updating release notes for 1.6.3

### DIFF
--- a/rn-ki.html.md.erb
+++ b/rn-ki.html.md.erb
@@ -6,6 +6,19 @@ list_style_none: true
 
 This topic contains release notes for Pivotal Cloud Foundry (PCF) Metrics.
 
+## <a id='163'></a>v1.6.3
+
+**Release Date: Feburary 28, 2020**
+
+### Fixed Issues
+
+<ul>
+  <li> 
+    Resolves PCF Metrics v1.6.x Incompatibility with Node.js Buildpack by packaging the 1.7.8 version of the buildpack. 
+    [Custom buildpacks must be enabled in Ops Manager](https://docs.pivotal.io/platform/application-service/adminguide/buildpacks.html) for the issue to be resolved.  
+  </li>
+</ul>
+
 ## <a id='162'></a>v1.6.2
 
 **Release Date: January 16, 2020**


### PR DESCRIPTION
Added note about fixing the buildpack issue
Included caveat about ops manager needing custom buildpacks to be enabled.