### PR TITLE
update 1.6.4 release notes

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -7,7 +7,7 @@ owner: PCF Metrics
 Pivotal Cloud Foundry (PCF) Metrics stores logs, metrics data, and event data from apps running on PCF for the past 14 days.
 It graphically presents this data to help operators and developers better understand the health and performance of their apps.
 
-## What's New in PCF Metrics v1.6
+##<a id='new'></a> What's New in PCF Metrics v1.6
 
 In addition to the out-of-the-box features provided in previous versions, PCF Metrics v1.6 introduces the following new functionality:
 
@@ -22,7 +22,7 @@ In addition to the out-of-the-box features provided in previous versions, PCF Me
 | Automated Logs Storage Pruning | [Installing PCF Metrics](./installing.html#step2) |
 
 
-## Product Snapshot
+##<a id='snapshot'></a> Product Snapshot
 
 The following table provides version and version-support information about PCF Metrics.
 
@@ -36,7 +36,7 @@ The following table provides version and version-support information about PCF M
 | IPsec support | Yes |
 
 
-## PCF Metrics User Guide
+##<a id='user-guide'></a> PCF Metrics User Guide
 
 See the following topics for details about PCF Metrics:
 

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -29,7 +29,7 @@ The following table provides version and version-support information about PCF M
 | Element | Details |
 |------|---------|
 | Tile version | v1.6.4 |
-| Release date | March 5, 2020 |
+| Release date | March 3, 2020 |
 | Compatible Ops Manager version(s) | v2.3 and later |
 | Compatible Pivotal Application Service (PAS) version(s) | v2.3 and later |
 | IaaS support | AWS, Azure, GCP, OpenStack, and vSphere |

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -28,8 +28,8 @@ The following table provides version and version-support information about PCF M
 
 | Element | Details |
 |------|---------|
-| Tile version | v1.6.3 |
-| Release date | February 28, 2020 |
+| Tile version | v1.6.4 |
+| Release date | March 5, 2020 |
 | Compatible Ops Manager version(s) | v2.3 and later |
 | Compatible Pivotal Application Service (PAS) version(s) | v2.3 and later |
 | IaaS support | AWS, Azure, GCP, OpenStack, and vSphere |

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -15,16 +15,16 @@ see [PCF Metrics Product Architecture](./architecture.html).
 
 Before you install or upgrade PCF Metrics, you must do the following:
 
-+ **For PCF Metrics v1.6.3:** 
++ **For PCF Metrics v1.6.3 and later:** 
 When you install PCF Metrics, you must have the **Enable custom buildpacks** checkbox
 selected in the **App Containers** pane in the Pivotal Application Service (PAS) tile.
 
     This checkbox is enabled by default.
-You need custom buildpacks enabled because PCF Metrics v1.6.3 and later requires,
-and is packaged with, the custom Node.js buildpack v1.7.8.
-<p class="note"><strong>Note:</strong> PCF Metrics v1.6.3 does not work in air-gapped environments
-because it does not have the offline buildpack packaged with it.
-</p>
+    You need custom buildpacks enabled because PCF Metrics v1.6.3 and later requires,
+    and is packaged with, the custom Node.js buildpack v1.7.8.
+    <p class="note"><strong>Note:</strong> PCF Metrics v1.6.3 does not work in air-gapped environments
+    because it does not have the offline buildpack packaged with it.
+    </p>
 
 + **For custom metrics:** To use the [Custom Metrics](./monitoringpcfmetrics.html#custom-metrics) feature of the PCF Metrics tile,
 you must have the Metrics Forwarder tile installed.

--- a/rn-ki.html.md.erb
+++ b/rn-ki.html.md.erb
@@ -6,6 +6,20 @@ list_style_none: true
 
 This topic contains release notes for Pivotal Cloud Foundry (PCF) Metrics.
 
+## <a id='164'></a>v1.6.4
+
+**Release Date: March 5, 2020**
+
+### Fixed Issues
+
+<ul>
+  <li> 
+    Resolves <a href="#issues">PCF Metrics v1.6.x Incompatibility with Node.js Buildpack</a>
+    for air-gapped environments by packaging the offline Node.js buildpack v1.7.8.
+    For more information, see <a href="./installing.html#prereqs">Prerequisites</a> in <em>Installing PCF Metrics</em>.
+  </li>
+</ul>
+
 ## <a id='163'></a>v1.6.3
 
 **Release Date: Feburary 28, 2020**

--- a/rn-ki.html.md.erb
+++ b/rn-ki.html.md.erb
@@ -8,7 +8,7 @@ This topic contains release notes for Pivotal Cloud Foundry (PCF) Metrics.
 
 ## <a id='1-6-4'></a>v1.6.4
 
-**Release Date: March 5, 2020**
+**Release Date: March 3, 2020**
 
 ### Fixed Issues
 

--- a/rn-ki.html.md.erb
+++ b/rn-ki.html.md.erb
@@ -6,7 +6,7 @@ list_style_none: true
 
 This topic contains release notes for Pivotal Cloud Foundry (PCF) Metrics.
 
-## <a id='164'></a>v1.6.4
+## <a id='1-6-4'></a>v1.6.4
 
 **Release Date: March 5, 2020**
 
@@ -14,20 +14,20 @@ This topic contains release notes for Pivotal Cloud Foundry (PCF) Metrics.
 
 <ul>
   <li> 
-    Resolves <a href="#issues">PCF Metrics v1.6.x Incompatibility with Node.js Buildpack</a>
-    for air-gapped environments by packaging the offline Node.js buildpack v1.7.8.
+    Resolves the <a href="#issues">Packaged Non-Offline Buildpack</a> issue.<br>
+    PCF Metrics v1.6.4 can be used in air-gapped environments because it packages the offline Node.js buildpack v1.7.8.
     For more information, see <a href="./installing.html#prereqs">Prerequisites</a> in <em>Installing PCF Metrics</em>.
   </li>
 </ul>
 
-## <a id='163'></a>v1.6.3
+## <a id='1-6-3'></a>v1.6.3
 
 **Release Date: Feburary 28, 2020**
-### Known Issues
+### <a name="1-6-3-issues"></a>Known Issues
 
-#### Packaged non-offline buildpack
+#### Packaged Non-Offline Buildpack
 
-The Node.js Buildpack requires the internet and will not work for air-gapped environments.
+The Node.js buildpack requires the internet and does not work for air-gapped environments.
 
 ### Fixed Issues
 
@@ -39,7 +39,7 @@ The Node.js Buildpack requires the internet and will not work for air-gapped env
   </li>
 </ul>
 
-## <a id='162'></a>v1.6.2
+## <a id='1-6-2'></a>v1.6.2
 
 **Release Date: January 16, 2020**
 
@@ -61,7 +61,7 @@ This release includes the following component version upgrades:
 <li>Locked os-conf to version 20.0.0</li>
 </ul>
 
-## <a id='161'></a>v1.6.1
+## <a id='1-6-1'></a>v1.6.1
 
 **Release Date: August 5, 2019**
 
@@ -89,7 +89,7 @@ This release includes the following component version upgrades:
 <li>Upgrade to CF CLI v1.16.0</li>
 </ul>
 
-## <a id='160'></a>v1.6.0
+## <a id='1-6-0'></a>v1.6.0
 
 **Release Date: January 10, 2019**
 


### PR DESCRIPTION
1.6.4 just packages offline buildpack to fix installation in air-gapped environments