### PR TITLE
Remove pivotal mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Documentation for Pivotal App Metrics
+# Documentation for App Metrics
 
-This is the source repo for documentation for Pivotal App Metrics. Our team can be
+This is the source repo for documentation for App Metrics. Our team can be
 found in the `pivotal-app-metrics` channel on slack.
 
 The source documents are located in the docs-content folder. 
@@ -9,13 +9,7 @@ UPDATE ALL OF THE FOLLOWING
 
 If you want to know how to view a local version of these docs as they will appear on docs.pivotal.io, see https://github.com/pivotal-cf/docs-partners-template/blob/master/README.md. 
 
-If you would like to provide feedback on the architecture diagrams included in this documentation, see the following links:
+If you would like to provide feedback on the architecture diagrams included in this documentation, see the following link:
 
 * General architecture diagram: 
-https://docs.pivotal.io/pcf-metrics/1-4/architecture.html#overview
-
-* Data flow diagram: 
-https://docs.pivotal.io/pcf-metrics/1-4/architecture.html#data-flow
-
-* User request diagram: 
-https://docs.pivotal.io/pcf-metrics/1-4/architecture.html#user-flow
+https://docs.pivotal.io/app-metrics/architecture.html

--- a/api/index.html.md.erb
+++ b/api/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
-breadcrumb: Pivotal App Metrics Documentation
-title: Pivotal App Metrics API
-owner: Pivotal App Metrics
+breadcrumb: App Metrics Documentation
+title: App Metrics API
+owner: App Metrics
 list_style_none: true 
 ---
 

--- a/api/monitors.html.md.erb
+++ b/api/monitors.html.md.erb
@@ -1,7 +1,7 @@
 ---
-breadcrumb: Pivotal App Metrics Documentation
-title: Pivotal App Metrics Monitor Configuration
-owner: Pivotal App Metrics
+breadcrumb: App Metrics Documentation
+title: App Metrics Monitor Configuration
+owner: App Metrics
 list_style_none: true 
 ---
 

--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -1,13 +1,13 @@
 ---
-breadcrumb: Pivotal App Metrics Documentation
-title: Pivotal App Metrics Product Architecture
-owner: Pivotal App Metrics
+breadcrumb: App Metrics Documentation
+title: App Metrics Product Architecture
+owner: App Metrics
 list_style_none: true 
 ---
 
 ## <a id="overview"></a>Overview
 
-The diagram below shows the components of App Metrics and the Cloud Foundry components
+The diagram below shows the components of App Metrics and the Pivotal Cloud Foundry components
 that the App Metrics system interacts with.
 
 <%= image_tag("app-metrics-2-0-architecture.svg", :alt => "App Metrics 2.0 architecture") %>
@@ -33,7 +33,7 @@ App Metrics uses the Metric Store tile for two purposes:
 * Registering monitors to receive alerts when the metrics surpass the monitor thresholds
 
 For more information about the Metric Store tile,
-see [Metric Store for PCF](https://docs.pivotal.io/metric-store/0-3/index.html).
+see [Metric Store for PCF](https://docs.pivotal.io/metric-store).
 
 ## <a id="custom-metrics"></a> Custom Metrics
 
@@ -80,4 +80,4 @@ the [PostgreSQL documentation](https://www.postgresql.org/docs/11/ssl-tcp.html).
 
 **At Rest**: The PostgreSQL datastore does not store any sensitive information,
 so by default it is not encrypted.
-If you want to encrypt it, see [Disk Encryption](https://docs.pivotal.io/platform/2-8/security/pcf-infrastructure/disk-encrypt.html).
+If you want to encrypt it, see [Disk Encryption](https://docs.pivotal.io/platform/security/pcf-infrastructure/disk-encrypt.html).

--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -7,14 +7,14 @@ list_style_none: true
 
 ## <a id="overview"></a>Overview
 
-The diagram below shows the components of App Metrics and the Pivotal Cloud Foundry components
+The diagram below shows the components of App Metrics and the Platform components
 that the App Metrics system interacts with.
 
 <%= image_tag("app-metrics-2-0-architecture.svg", :alt => "App Metrics 2.0 architecture") %>
 
 Understanding the diagram:
 
-* The cornered rectangles represent Pivotal Cloud Foundry tiles that App Metrics v2.0 depends on.
+* The cornered rectangles represent Platform tiles that App Metrics v2.0 depends on.
 * The rounded rectangles represent customer interaction points.
 * The cylinders represent the data storage components of App Metrics v2.0.
 * The <span style="background:#9AC0CD">blue</span> components are packaged with App Metrics v2.0.
@@ -33,12 +33,12 @@ App Metrics uses the Metric Store tile for two purposes:
 * Registering monitors to receive alerts when the metrics surpass the monitor thresholds
 
 For more information about the Metric Store tile,
-see [Metric Store for PCF](https://docs.pivotal.io/metric-store).
+see the [Metric Store documentation](https://docs.pivotal.io/metric-store).
 
 ## <a id="custom-metrics"></a> Custom Metrics
 
 Metrics Registrar can be used to collect custom application metrics.
-Metrics Registrar is bundled alongside PAS which is already a dependency of App Metrics v2.0.
+Metrics Registrar is bundled alongside TAS which is already a dependency of App Metrics v2.0.
 
 To see custom application metrics in App Metrics v2.0, Metrics Registrar
 needs to be configured to scrape Prometheus-style metrics from your applications.
@@ -51,7 +51,7 @@ For more information, see:
 
 ## <a id="logs"></a> Logs
 
-The Log Store is a time series database for storing and querying Cloud Foundry application logs.
+The Log Store is a time series database for storing and querying application logs.
 
 Logs are streamed into the store via the Loggregator V2 endpoint and stored via the Influx Storage Engine.
 Log Store provides the capability for distributed configurations, scaled out to use multiple nodes.

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -4,7 +4,9 @@ title: App Metrics
 owner: App Metrics
 ---
 
-App Metrics can display up to six weeks worth of logs, metrics data, and event data from apps running on the Pivotal Platform. It graphically presents this data to help operators and developers better understand the health and performance of their apps.
+App Metrics can display up to six weeks worth of logs, metrics data, and event data from apps running on the
+Pivotal Application Service. It graphically presents this data to help operators and developers better understand
+the health and performance of their apps.
 
 ##<a id='new'></a> What's New in App Metrics v2.0
 

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -5,7 +5,7 @@ owner: App Metrics
 ---
 
 App Metrics can display up to six weeks worth of logs, metrics data, and event data from apps running on the
-Pivotal Application Service. It graphically presents this data to help operators and developers better understand
+VMware Tanzu Application Service. It graphically presents this data to help operators and developers better understand
 the health and performance of their apps.
 
 ##<a id='new'></a> What's New in App Metrics v2.0
@@ -33,6 +33,6 @@ The following table provides version and version-support information about App M
 | Tile version | v2.0 |
 | Release date | 2020 |
 | Compatible Ops Manager version(s) | v2.6 and later |
-| Compatible Elastic Runtime version(s) | v2.6 and later |
+| Compatible Tanzu Application Service version(s) | v2.6 and later |
 | IaaS support | AWS, Azure, GCP, OpenStack, and vSphere |
 | IPsec support | Yes |

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -1,41 +1,41 @@
 ---
-breadcrumb: Pivotal App Metrics Documentation
-title: Installing Pivotal App Metrics
-owner: Pivotal App Metrics
+breadcrumb: App Metrics Documentation
+title: Installing App Metrics
+owner: App Metrics
 list_style_none: true 
 ---
 
-<p class="note"><b>Note:</b> Pivotal App Metrics v2.0 requires <a href="https://docs.pivotal.io/metric-store" target="_blank">Metric Store</a> as its metrics datastore. You will need to install this tile before installing Pivotal App Metrics.</p>
+<p class="note"><b>Note:</b> App Metrics v2.0 requires <a href="https://docs.pivotal.io/metric-store" target="_blank">Metric Store</a> as its metrics datastore. You will need to install this tile before installing App Metrics.</p>
 
-## <a id='AddTile'></a>Download Pivotal App Metrics
+## <a id='AddTile'></a>Download App Metrics
 <ol>
 <li>After you have installed the <a href="https://docs.pivotal.io/metric-store" target="_blank">Metric Store</a> tile in Ops Manager,
-    download the Pivotal App Metrics 2.0 product file from <a href="https://network.pivotal.io/products/apm" target="_blank">Pivotal Network</a>.</li>
+    download the App Metrics 2.0 product file from <a href="https://network.pivotal.io/products/apm" target="_blank">Pivotal Network</a>.</li>
 <li>Navigate to the Ops Manager Installation Dashboard and click Import a Product to upload the product file.</li>
-<li>Under the Import a Product button, click + next to the version number of Pivotal App Metrics. This adds the tile to your staging area.</li>
+<li>Under the Import a Product button, click + next to the version number of App Metrics. This adds the tile to your staging area.</li>
 </ol>
 
 ## <a id='ConfigureAzs'></a>Configure AZs and Networks
-To start using Pivotal App Metrics, you need to configure the Pivotal App Metrics tile by performing the following steps:
+To start using App Metrics, you need to configure the App Metrics tile by performing the following steps:
 <ol>
-<li>Click the Pivotal App Metrics tile on the Ops Manager Installation Dashboard.</li>
+<li>Click the App Metrics tile on the Ops Manager Installation Dashboard.</li>
 <li>Navigate to Assign AZs and Networks and do the following:</li>
 <ul>
 <li>Select an Availability Zone (AZ) for placing singleton jobs.</li>
 <li>Select one or more AZs for balancing other jobs. (Note: To create a highly available environment,
 VMware recommends selecting multiple AZs.)</li>
-<li>Select Network for installing Pivotal App Metrics.</li>
+<li>Select Network for installing App Metrics.</li>
 </ul>
 </ol>
 
 ## <a id='ConfigureFeatures'></a>(Optional) Configure App Metrics Features
-Here you can configure the settings for Pivotal App Metrics components, including Log Store.
+Here you can configure the settings for App Metrics components, including Log Store.
 <ol>
-<li>Click the Pivotal App Metrics tile on the Ops Manager Installation Dashboard.</li>
-<li>Navigate to the Pivotal App Metrics Components Config pane.</li>
-<li>To disable the Logs Drawer on the Pivotal App Metrics dashboard, deselect the "Pivotal App Metrics Enable Logs" checkbox (enabled by default).</li>
-<li>Set the Pivotal App Metrics Logs Prune Threshold disk capacity percentage (set to 80% by default). This is the disk percentage at which Log Store will start to prune the oldest logs first.</li>
-<li>Set the Pivotal App Metrics Logs Prune Interval (set to two minutes by default). This is the frequency at which Log Store will check the disk capacity to make the pruning decision.</li>
+<li>Click the App Metrics tile on the Ops Manager Installation Dashboard.</li>
+<li>Navigate to the App Metrics Components Config pane.</li>
+<li>To disable the Logs Drawer on the App Metrics dashboard, deselect the "App Metrics Enable Logs" checkbox (enabled by default).</li>
+<li>Set the App Metrics Logs Prune Threshold disk capacity percentage (set to 80% by default). This is the disk percentage at which Log Store will start to prune the oldest logs first.</li>
+<li>Set the App Metrics Logs Prune Interval (set to two minutes by default). This is the frequency at which Log Store will check the disk capacity to make the pruning decision.</li>
 <li>To enable a SOCKS proxy, select **Enable Socks Proxy** and set the `HTTP_PROXY`
     or `HTTPS_PROXY` environment variable to the URL of your proxy.
     This checkbox sets the `USE_SOCKS_PROXY` environment variable, which overrides the protocol for the proxy
@@ -43,11 +43,11 @@ Here you can configure the settings for Pivotal App Metrics components, includin
 </ol>
 
 ## <a id='ConfigureSyslog'></a>(Optional) Configure Syslog Forwarding
-Pivotal App Metrics supports forwarding syslog to an external log management service such as Papertrail, Splunk, or a custom enterprise log sink. You may find the VM logs useful for debugging problems in the system.
+App Metrics supports forwarding syslog to an external log management service such as Papertrail, Splunk, or a custom enterprise log sink. You may find the VM logs useful for debugging problems in the system.
 
 To enable remote syslog forwarding for PCF Healthwatch, do the following:
 <ol>
-<li>Click the Pivotal App Metrics tile on the Ops Manager Installation Dashboard.</li>
+<li>Click the App Metrics tile on the Ops Manager Installation Dashboard.</li>
 <li>Navigate to the Syslog pane.</li>
 <li>Select Yes without encryption or Yes with TLS encryption to enable syslog forwarding.</li>
 <li>For External Syslog Host, enter the address of syslog server where you want logs sent, such as [logs.example.com].</li>

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -45,7 +45,7 @@ Here you can configure the settings for App Metrics components, including Log St
 ## <a id='ConfigureSyslog'></a>(Optional) Configure Syslog Forwarding
 App Metrics supports forwarding syslog to an external log management service such as Papertrail, Splunk, or a custom enterprise log sink. You may find the VM logs useful for debugging problems in the system.
 
-To enable remote syslog forwarding for PCF Healthwatch, do the following:
+To enable remote syslog forwarding for Healthwatch, do the following:
 <ol>
 <li>Click the App Metrics tile on the Ops Manager Installation Dashboard.</li>
 <li>Navigate to the Syslog pane.</li>

--- a/monitoring-pcf-metrics.html.md.erb
+++ b/monitoring-pcf-metrics.html.md.erb
@@ -6,9 +6,9 @@ list_style_none: true
 ---
 
 This topic explains how to monitor the health of the App Metrics service using the logs, metrics,
-and Key Performance Indicators (KPIs) emitted by Cloud Foundry and the App Metrics application itself.
+and Key Performance Indicators (KPIs) emitted by Tanzu Application Service and the App Metrics application itself.
 
-For more information about monitoring PCF, see [Monitoring Cloud Foundry](https://docs.pivotal.io/pivotalcf/monitoring/index.html).
+For more information about monitoring TAS, see [Monitoring TAS](https://docs.pivotal.io/pivotalcf/monitoring/index.html).
 
 ## <a id="healthwatch"></a>Healthwatch
 

--- a/rn-ki.html.md.erb
+++ b/rn-ki.html.md.erb
@@ -1,19 +1,19 @@
 ---
-breadcrumb: Pivotal App Metrics Documentation
-title: Pivotal App Metrics Release Notes and Known Issues
-owner: Pivotal App Metrics
+breadcrumb: App Metrics Documentation
+title: App Metrics Release Notes and Known Issues
+owner: App Metrics
 list_style_none: true 
 ---
 
-This topic contains release notes for Pivotal App Metrics 2.0 and beyond.
+This topic contains release notes for App Metrics 2.0 and beyond.
 
 ## <a id='20'></a>v2.0
 
 **Release Date: Not yet released.**
 
-### <a id="new-features"></a>New Features in Pivotal App Metrics v2.0
+### <a id="new-features"></a>New Features in App Metrics v2.0
 
-Pivotal App Metrics v2.0 includes the following new features:
+App Metrics v2.0 includes the following new features:
 
 <ul>
 <li>Spring Boot Micrometer and tagged metrics support</li>
@@ -30,11 +30,11 @@ Pivotal App Metrics v2.0 includes the following new features:
 
 ### <a id="issues"></a>Known Issues
 
-The following sections describe the known issues in Pivotal App Metrics v2.0.
+The following sections describe the known issues in App Metrics v2.0.
 
 #### Compatibility with Pivotal Application Service (formerly Elastic Runtime)
 
-Pivotal App Metrics v2.0 requires the following versions of Pivotal Application Service:
+App Metrics v2.0 requires the following versions of Pivotal Application Service:
 
 * v2.6: v2.6.x and later
 * v2.7: all patches within minor
@@ -42,7 +42,7 @@ Pivotal App Metrics v2.0 requires the following versions of Pivotal Application 
 
 #### Compatibility with Pivotal Cloud Foundry Operations Manager
 
-Pivotal App Metrics v2.0 requires the following versions of Pivotal Cloud Foundry Operations Manager:
+App Metrics v2.0 requires the following versions of Pivotal Cloud Foundry Operations Manager:
 
 * v2.6: v2.6.x and later
 * v2.7: all patches within minor
@@ -54,7 +54,7 @@ Please note that if the application you are monitoring is not configured to acce
 
 #### Custom Metric Process Labels
 
-Pivotal App Metrics v2.0 introduces a new application hierarchy to support multiple process types from CAPI v3. Processes that contain apporpriately tagged envelopes will be available for metric filtering, and will be labled accordingly within the charts.
+App Metrics v2.0 introduces a new application hierarchy to support multiple process types from CAPI v3. Processes that contain apporpriately tagged envelopes will be available for metric filtering, and will be labled accordingly within the charts.
 
 There are some metrics, including custom and network metrics, that may not have proper process tagging available. In these cases, the process will be labeled `unknown`.
 

--- a/rn-ki.html.md.erb
+++ b/rn-ki.html.md.erb
@@ -32,17 +32,17 @@ App Metrics v2.0 includes the following new features:
 
 The following sections describe the known issues in App Metrics v2.0.
 
-#### Compatibility with Pivotal Application Service (formerly Elastic Runtime)
+#### Compatibility with VMware Tanzu Application Service
 
-App Metrics v2.0 requires the following versions of Pivotal Application Service:
+App Metrics v2.0 requires the following versions of VMware Tanzu Application Service:
 
 * v2.6: v2.6.x and later
 * v2.7: all patches within minor
 * v2.8: all patches within minor
 
-#### Compatibility with Pivotal Cloud Foundry Operations Manager
+#### Compatibility with Operations Manager
 
-App Metrics v2.0 requires the following versions of Pivotal Cloud Foundry Operations Manager:
+App Metrics v2.0 requires the following versions of Operations Manager:
 
 * v2.6: v2.6.x and later
 * v2.7: all patches within minor
@@ -58,4 +58,4 @@ App Metrics v2.0 introduces a new application hierarchy to support multiple proc
 
 There are some metrics, including custom and network metrics, that may not have proper process tagging available. In these cases, the process will be labeled `unknown`.
 
-This will improve as additional support for multi-process tagging is backported to previous PAS versions.
+This will improve as additional support for multi-process tagging is backported to previous TAS versions.

--- a/sizing.html.md.erb
+++ b/sizing.html.md.erb
@@ -1,7 +1,7 @@
 ---
-breadcrumb: Pivotal App Metrics Documentation
-title: Sizing Pivotal App Metrics for Your System 
-owner: Pivotal App Metrics
+breadcrumb: App Metrics Documentation
+title: Sizing App Metrics for Your System
+owner: App Metrics
 list_style_none: true 
 ---
 
@@ -20,10 +20,10 @@ are part of the App Metrics tile, and so their scaling will be discussed more in
 ##<a id='metrics-datastore'></a> Scale the Metrics Datastore
 
 App Metrics retrieves metrics from Metric Store, which has its own configuration for resizing.
-For information, see [Metric Store documentation](https://docs.pivotal.io/metric-store/0-3/installing.html#-metric-store-for-pcf-resources).
+For information, see [Metric Store documentation](https://docs.pivotal.io/metric-store/installing.html#-metric-store-for-pcf-resources).
 
 Currently, VMware recommends that you scale vertically rather than horizontally.
-See [Limitations](https://docs.pivotal.io/metric-store/0-3/index.html#limitations)
+See [Limitations](https://docs.pivotal.io/metric-store/index.html#limitations)
 in the _Metric Store_ documentation.
 
 

--- a/sizing.html.md.erb
+++ b/sizing.html.md.erb
@@ -10,7 +10,7 @@ Operators can use these procedures to optimize App Metrics for high capacity or 
 
 After your deployment has been running for a while, use the information in this topic to scale your running deployment.
 
-If you are not familiar with the App Metrics components, review [PCF Metrics Product Architecture](./architecture.html) before reading this topic.
+If you are not familiar with the App Metrics components, review [App Metrics Product Architecture](./architecture.html) before reading this topic.
 
 App Metrics depends on 3 datastores, the Metric Store, the Log Store, and the Postgres database.
 

--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -1,7 +1,7 @@
 ---
-breadcrumb: Pivotal App Metrics Documentation
-title: Troubleshooting Pivotal App Metrics
-owner: Pivotal App Metrics
+breadcrumb: App Metrics Documentation
+title: Troubleshooting App Metrics
+owner: App Metrics
 list_style_none: true 
 ---
 
@@ -27,11 +27,11 @@ it may be worth investigating what is wrong with that particular component.
 
 ### <a id="troubleshooting-cf-api"></a> Troubleshooting CF API
 
-See the [Cloud Controller documentation](https://docs.pivotal.io/platform/application-service/2-8/concepts/architecture/cloud-controller.html).
+See the [Cloud Controller documentation](https://docs.pivotal.io/platform/application-service/concepts/architecture/cloud-controller.html).
 
 ### <a id="troubleshooting-uaa"></a> Troubleshooting UAA
 
-See the [UAA documentation](https://docs.pivotal.io/platform/application-service/2-8/concepts/architecture/uaa.html).
+See the [UAA documentation](https://docs.pivotal.io/platform/application-service/concepts/architecture/uaa.html).
 
 ### <a id="troubleshooting-metric-store"></a> Troubleshooting Metric Store
 

--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -1,15 +1,15 @@
 ---
-breadcrumb: Pivotal App Metrics Documentation
-title: Monitoring and Troubleshooting Apps with Pivotal App Metrics
-owner: Pivotal App Metrics
+breadcrumb: App Metrics Documentation
+title: Monitoring and Troubleshooting Apps with App Metrics
+owner: App Metrics
 list_style_none: true 
 ---
 
-This topic describes how developers can monitor and troubleshoot their apps using Pivotal App Metrics.
+This topic describes how developers can monitor and troubleshoot their apps using App Metrics.
 
 ## <a id="overview"></a> Overview
 
-Pivotal App Metrics helps you understand and troubleshoot the health and performance of your apps by offering the following indicators, data, and visualizations:
+App Metrics helps you understand and troubleshoot the health and performance of your apps by offering the following indicators, data, and visualizations:
 
 * [Latency](#latency): Response times for your application
 * [Traffic](#traffic): Number of requests made for your application
@@ -19,13 +19,13 @@ Pivotal App Metrics helps you understand and troubleshoot the health and perform
 * [App Events](#events): A chart of update, start, stop, crash, SSH, and staging failure events
 * [Logs](#logs): A list of app logs that you can search, filter, and download
 
-The following sections describe a standard workflow for using Pivotal App Metrics to monitor or troubleshoot your apps.
+The following sections describe a standard workflow for using App Metrics to monitor or troubleshoot your apps.
 
 ##<a id='get-started'></a> View an App
 
-In a browser, navigate to `appmetrics.YOUR-SYSTEM-DOMAIN` and log in with your User Account and Authentication (UAA) credentials. Choose an app from the search bar for which you want to view metrics and/or logs. Pivotal App Metrics respects UAA permissions such that you can view any app that runs in a space that you have access to. 
+In a browser, navigate to `appmetrics.YOUR-SYSTEM-DOMAIN` and log in with your User Account and Authentication (UAA) credentials. Choose an app from the search bar for which you want to view metrics and/or logs. App Metrics respects UAA permissions such that you can view any app that runs in a space that you have access to.
 
-Pivotal App Metrics displays app data for a given time frame. See the sections below to [Change the Time Frame](#time) for the dashboard.
+App Metrics displays app data for a given time frame. See the sections below to [Change the Time Frame](#time) for the dashboard.
 
 ## <a id="time"></a>Change the Time Frame
 
@@ -43,7 +43,7 @@ To enable auto-refresh, click the **REFRESH** button next to the time selection 
 
 ## <a id="app-instance"></a>View Metrics at the Process and Application Instance Level
 
-Pivotal App Metrics relays metric data at the app process level to allow for an in-depth troubleshooting experience, even across rolling deployment. Users are able to view the app metrics related to a specific process and further drill down into specific instances within those processes, which correlates directly with the processes and app instances shown in [Apps Manager](https://docs.pivotal.io/pivotalcf/console/manage-apps.html#manage-app).
+App Metrics relays metric data at the app process level to allow for an in-depth troubleshooting experience, even across rolling deployment. Users are able to view the app metrics related to a specific process and further drill down into specific instances within those processes, which correlates directly with the processes and app instances shown in [Apps Manager](https://docs.pivotal.io/pivotalcf/console/manage-apps.html#manage-app).
 
 The dashboard will display metrics aggregated across all processes by default. To view metrics by specific process, select a process type from the dropdown near the upper-left of the dashboard.
 
@@ -55,7 +55,7 @@ To view metrics for a specific app instance (or selection of specific instances)
 
 ##<a id='metrics'></a> Interpreting Metrics
 
-The default metrics charts included with Pivotal App Metrics provide high-level indicators of the Four Golden Signals for monitoring the health of applications running on distributed systems: Latency, Traffic, Errors, Saturation.
+The default metrics charts included with App Metrics provide high-level indicators of the Four Golden Signals for monitoring the health of applications running on distributed systems: Latency, Traffic, Errors, Saturation.
 
 The following sections explain how to use each of the charts on the dashboard to monitor and troubleshoot your app.
 
@@ -77,7 +77,7 @@ they show No Data or zeros for the default Latency, Traffic, and Errors metrics.
 
 ### <a id='saturation'></a> Saturation (Container Metrics)
 
-The following **Container Metrics** charts are available on the Pivotal App Metrics dashboard to help monitor resource saturation:
+The following **Container Metrics** charts are available on the App Metrics dashboard to help monitor resource saturation:
 
 * CPU usage percentage:<br><br>A spike in CPU might point to a process that is computationally heavy. Scaling app instances can relieve the immediate pressure, but you need to investigate the app to better understand and fix the root cause.<br><br>
 
@@ -102,7 +102,7 @@ You can add custom metrics charts to your dashboard, including Spring Boot Actua
 
 In order to get custom, Actuator, or Micrometer metrics into the Metrics Store, you will need to bind Metric Registrar to your app and register your endpoint. For more information, see [Configuring the Metric Registrar](https://docs.pivotal.io/pivotalcf/metric-registrar/index.html).
 
-If you want to view custom metrics, you can configure your apps to emit those metrics out of the [Loggregator Firehose](https://docs.pivotal.io/pivotalcf/loggregator/architecture.html#firehose) and then view these metrics on the Pivotal App Metrics dashboard.
+If you want to view custom metrics, you can configure your apps to emit those metrics out of the [Loggregator Firehose](https://docs.pivotal.io/pivotalcf/loggregator/architecture.html#firehose) and then view these metrics on the App Metrics dashboard.
 
 In addition, Spring Boot apps with actuators or Micrometer metrics implemented emit [these metrics](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html) out of the box, without any changes to source code.
 
@@ -148,7 +148,7 @@ For more information about indicator formatting, please see the [Indicator Proto
 
 Additional example PromQL can also be found for any of the default charts on the dashboard by clicking the `Info` menu in the upper-right of any chart, or by visiting the [PromQL Query Examples](https://prometheus.io/docs/prometheus/latest/querying/examples/) documentation.
 
-### cURLing Your Indicator Document to Pivotal App Metrics
+### cURLing Your Indicator Document to App Metrics
 Once you have your indicator document prepared, you can push it to App Metrics via cURL.
 
 Linux/Mac:


### PR DESCRIPTION
see [Tracker story: Remove mentions of Pivotal from the docs](https://www.pivotaltracker.com/story/show/171964282)

in the end we weren't sure what to do with Pivotal Cloud Foundry or Pivotal Application Service, as they were still used on PivNet, so we left those references in tact.

*Main change*: Replace all "Pivotal App Metrics" with "App Metrics"

other minor changes:
- clean up links to remove specific versions e.g. `platform/2-8` and `metric-store/0-3`