### PR TITLE
Fix domain name used to access App Metrics UI

### DIFF
--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -23,7 +23,7 @@ The following sections describe a standard workflow for using App Metrics to mon
 
 ##<a id='get-started'></a> View an App
 
-In a browser, navigate to `metrics.sys.DOMAIN` and log in with your User Account and Authentication (UAA) credentials. Choose an app from the search bar for which you want to view metrics and/or logs. App Metrics respects UAA permissions such that you can view any app that runs in a space that you have access to.
+In a browser, navigate to `appmetrics.sys.DOMAIN` and log in with your User Account and Authentication (UAA) credentials. Choose an app from the search bar for which you want to view metrics and/or logs. App Metrics respects UAA permissions such that you can view any app that runs in a space that you have access to.
 
 App Metrics displays app data for a given time frame. See the sections below to [Change the Time Frame](#time) for the dashboard.
 


### PR DESCRIPTION
I just installed App Metrics and tried to follow the docs to access it, but it seems like the domain name is incorrect.